### PR TITLE
fix AppCompatImageHelper applySupportImageTint VectorDrawable bug

### DIFF
--- a/magicasakura/src/main/java/com/bilibili/magicasakura/widgets/AppCompatImageHelper.java
+++ b/magicasakura/src/main/java/com/bilibili/magicasakura/widgets/AppCompatImageHelper.java
@@ -148,7 +148,7 @@ class AppCompatImageHelper extends AppCompatBaseHelper<ImageView> {
             }
             setImageDrawable(tintDrawable);
             if (image == tintDrawable) {
-                tintDrawable.invalidateSelf();
+                mView.invalidate();
             }
             return true;
         }


### PR DESCRIPTION
VectorDrawableCompat invalidateSelf -> mDelegateDrawable(BitmapDrawable) invalidateSelf ->ImageView invalidateDrawable 
```java
    public void invalidateDrawable(@NonNull Drawable dr) {
        dr is 是BitmapDrawable  mDrawable是VectorDrawableCompat  不相等 所以不会重绘。
        if (dr == mDrawable) { 
            if (dr != null) {
                // update cached drawable dimensions if they've changed
                final int w = dr.getIntrinsicWidth();
                final int h = dr.getIntrinsicHeight();
                if (w != mDrawableWidth || h != mDrawableHeight) {
                    mDrawableWidth = w;
                    mDrawableHeight = h;
                    // updates the matrix, which is dependent on the bounds
                    configureBounds();
                }
            }
            /* we invalidate the whole view in this case because it's very
             * hard to know where the drawable actually is. This is made
             * complicated because of the offsets and transformations that
             * can be applied. In theory we could get the drawable's bounds
             * and run them through the transformation and offsets, but this
             * is probably not worth the effort.
             */
            invalidate();
        } else {
            super.invalidateDrawable(dr);
        }
    }
```

这个问题最终是VectorDrawableCompat的是的问题 已经提交官方修改 https://issuetracker.google.com/issues/110174719